### PR TITLE
feat: Phase 2 — expose already-implemented but unregistered tools

### DIFF
--- a/src/rabbitmq/handlers.py
+++ b/src/rabbitmq/handlers.py
@@ -246,3 +246,24 @@ def handle_shovel(rabbitmq_admin: RabbitMQAdmin, shovel_name: str, vhost: str = 
 def handle_list_users(rabbitmq_admin: RabbitMQAdmin) -> list[dict]:
     """List all users on the RabbitMQ broker."""
     return rabbitmq_admin.list_users()
+
+
+## Bindings
+
+
+def handle_get_bindings(
+    rabbitmq_admin: RabbitMQAdmin,
+    queue: str | None = None,
+    exchange: str | None = None,
+    vhost: str = "/",
+) -> list[dict]:
+    """Get bindings, optionally filtered by queue or exchange."""
+    return rabbitmq_admin.get_bindings(queue=queue, exchange=exchange, vhost=vhost)
+
+
+## Nodes
+
+
+def handle_get_node_information(rabbitmq_admin: RabbitMQAdmin, node_name: str) -> dict:
+    """Get detailed information about a specific node."""
+    return rabbitmq_admin.get_node_information(node_name=node_name)

--- a/src/rabbitmq/module.py
+++ b/src/rabbitmq/module.py
@@ -23,10 +23,14 @@ from .connection import RabbitMQConnection, validate_rabbitmq_name
 from .handlers import (
     handle_delete_exchange,
     handle_delete_queue,
+    handle_enqueue,
+    handle_fanout,
+    handle_get_bindings,
     handle_get_cluster_nodes,
     handle_get_definition,
     handle_get_exchange_info,
     handle_get_guidelines,
+    handle_get_node_information,
     handle_get_queue_info,
     handle_is_broker_in_alarm,
     handle_is_node_in_quorum_critical,
@@ -228,6 +232,22 @@ class RabbitMQModule:
                 raise AssertionError("RabbitMQ admin endpoints not connected.")
             return handle_get_definition(self.rmq_admin)
 
+        @self.mcp.tool()
+        def rabbitmq_broker_get_bindings(
+            queue: str | None = None, exchange: str | None = None, vhost: str = "/"
+        ) -> list[dict]:
+            """Get bindings, optionally filtered by queue or exchange. If neither is specified, returns all bindings in the vhost."""
+            if self.rmq_admin is None:
+                raise AssertionError("RabbitMQ admin endpoints not connected.")
+            return handle_get_bindings(self.rmq_admin, queue=queue, exchange=exchange, vhost=vhost)
+
+        @self.mcp.tool()
+        def rabbitmq_broker_get_node_information(node_name: str) -> dict:
+            """Get detailed information about a specific node in the cluster including memory, disk, uptime, and runtime details."""
+            if self.rmq_admin is None:
+                raise AssertionError("RabbitMQ admin endpoints not connected.")
+            return handle_get_node_information(self.rmq_admin, node_name)
+
     def __register_mutative_tools(self):
         @self.mcp.tool()
         def rabbitmq_broker_delete_queue(queue: str, vhost: str = "/") -> str:
@@ -263,3 +283,19 @@ class RabbitMQModule:
                 raise AssertionError("RabbitMQ admin endpoints not connected.")
             handle_update_definition(self.rmq_admin, server_definition)
             return "Updated successfully"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_enqueue(queue: str, message: str) -> str:
+            """Publish a message to a specific queue via AMQP. The queue will be declared if it does not exist."""
+            if self.rmq is None:
+                raise AssertionError("RabbitMQ AMQP connection not established.")
+            handle_enqueue(self.rmq, queue, message)
+            return f"Message published to queue {queue}"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_fanout(exchange: str, message: str) -> str:
+            """Publish a message to a fanout exchange via AMQP. The exchange will be declared if it does not exist."""
+            if self.rmq is None:
+                raise AssertionError("RabbitMQ AMQP connection not established.")
+            handle_fanout(self.rmq, exchange, message)
+            return f"Message published to fanout exchange {exchange}"


### PR DESCRIPTION
# Phase 2: Expose Already-Implemented but Unregistered Tools

**Branch:** `feat/phase2-expose-existing`
**Base:** `fix/phase1-bug-fixes-code-quality` (PR #17)
**Files changed:** 2 (handlers.py, module.py) | +57 lines

## Summary

Four functions existed in the codebase but were never registered as MCP tools — making them completely inaccessible to agents. This PR wires them up.

## New Tools

### Read-only (always available)

| Tool | Handler | API | Description |
|------|---------|-----|-------------|
| `rabbitmq_broker_get_bindings` | `handle_get_bindings` | `GET /api/bindings/{vhost}` | Get bindings, optionally filtered by queue or exchange. `admin.py` had the full implementation including queue/exchange filtering — never exposed. |
| `rabbitmq_broker_get_node_information` | `handle_get_node_information` | `GET /api/nodes/{name}` | Get detailed node info (memory, disk, uptime, runtime). Complements existing `get_cluster_nodes_info` which returns a summary list. |

### Mutative (requires `--allow-mutative-tools`)

| Tool | Handler | Protocol | Description |
|------|---------|----------|-------------|
| `rabbitmq_broker_enqueue` | `handle_enqueue` | AMQP | Publish a message to a specific queue. Declares queue if it doesn't exist. Handler existed in `handlers.py` since initial commit but was never imported or registered. |
| `rabbitmq_broker_fanout` | `handle_fanout` | AMQP | Publish a message to a fanout exchange. Declares exchange if it doesn't exist. Same situation — existed but never wired up. |

## Tool Count After This PR

| Tier | Before | After |
|------|--------|-------|
| Critical | 3 | 3 |
| Read-only | 14 | 16 (+2) |
| Mutative | 4 | 6 (+2) |
| **Total** | **21** | **25** |

## Testing

- All 44 existing tests pass
- `ruff check` clean
- Note: enqueue/fanout require a live AMQP connection to test end-to-end (no integration test suite yet — planned for Phase 6)

## Risk

Low. No existing behavior changed. Four new tools added, all backed by pre-existing implementations.
