### PR TITLE
feat: Phase 4A — multi-broker connection registry

### DIFF
--- a/src/rabbitmq/module.py
+++ b/src/rabbitmq/module.py
@@ -69,8 +69,20 @@ class RabbitMQModule:
     def __init__(self, mcp: FastMCP):
         """Initialize the RabbitMQ module."""
         self.mcp = mcp
-        self.rmq: RabbitMQConnection | None = None
-        self.rmq_admin: RabbitMQAdmin | None = None
+        self.brokers: dict[str, dict] = {}
+        self.active_alias: str | None = None
+
+    def _get_admin(self) -> RabbitMQAdmin:
+        """Return the active broker's admin client."""
+        if not self.active_alias or self.active_alias not in self.brokers:
+            raise AssertionError("No active broker. Call initialize_connection first.")
+        return self.brokers[self.active_alias]["rmq_admin"]
+
+    def _get_rmq(self) -> RabbitMQConnection:
+        """Return the active broker's AMQP connection."""
+        if not self.active_alias or self.active_alias not in self.brokers:
+            raise AssertionError("No active broker. Call initialize_connection first.")
+        return self.brokers[self.active_alias]["rmq"]
 
     def register_rabbitmq_management_tools(self, allow_mutative_tools: bool = False):
         """Install RabbitMQ tools to the MCP server."""
@@ -87,51 +99,91 @@ class RabbitMQModule:
             password: str,
             port: int = 5671,
             use_tls: bool = True,
+            alias: str | None = None,
         ) -> str:
             """Connect to a new RabbitMQ broker which authentication strategy is SIMPLE.
 
-            broker_hostname: The hostname of the broker. For example, b-a9565a64-da39-4afc-9239-c43a9376b5ba.mq.us-east-1.on.aws, b-9560b8e1-3d33-4d91-9488-a3dc4a61dfe7.mq.us-east-1.amazonaws.com
+            broker_hostname: The hostname of the broker.
             username: The username of user
             password: The password of user
+            alias: Optional name for this connection (default: hostname). Use to manage multiple brokers, e.g. 'blue', 'green', 'prod'.
             """
-            self.rmq = RabbitMQConnection(
+            alias = alias or broker_hostname
+            rmq = RabbitMQConnection(
                 hostname=broker_hostname,
                 username=username,
                 password=password,
                 port=port,
                 use_tls=use_tls,
             )
-            self.rmq_admin = RabbitMQAdmin(
+            rmq_admin = RabbitMQAdmin(
                 hostname=broker_hostname,
                 username=username,
                 password=password,
                 use_tls=use_tls,
             )
-            self.rmq_admin.test_connection()
-            return "successfully connected"
+            rmq_admin.test_connection()
+            self.brokers[alias] = {
+                "rmq": rmq,
+                "rmq_admin": rmq_admin,
+                "hostname": broker_hostname,
+            }
+            self.active_alias = alias
+            return f"Connected to {broker_hostname} as '{alias}' (active)"
 
         @self.mcp.tool()
         def rabbitmq_broker_initialize_connection_with_oauth(
             broker_hostname: str,
             oauth_token: str,
+            alias: str | None = None,
         ) -> str:
-            """Connect to a new RabbitMQ broker using OAuth. It only applies to RabbitMQ broker which authentication strategy is config_managed.
+            """Connect to a new RabbitMQ broker using OAuth.
 
-            broker_hostname: The hostname of the broker. For example, b-a9565a64-da39-4afc-9239-c43a9376b5ba.mq.us-east-1.on.aws, b-9560b8e1-3d33-4d91-9488-a3dc4a61dfe7.mq.us-east-1.amazonaws.com
+            broker_hostname: The hostname of the broker.
             oauth_token: A valid access token
+            alias: Optional name for this connection (default: hostname).
             """
-            self.rmq = RabbitMQConnection(
+            alias = alias or broker_hostname
+            rmq = RabbitMQConnection(
                 hostname=broker_hostname,
                 username="",
                 password=oauth_token,
             )
-            self.rmq_admin = RabbitMQAdmin(
+            rmq_admin = RabbitMQAdmin(
                 hostname=broker_hostname,
                 username="",
                 password=oauth_token,
             )
-            self.rmq_admin.test_connection()
-            return "successfully connected"
+            rmq_admin.test_connection()
+            self.brokers[alias] = {
+                "rmq": rmq,
+                "rmq_admin": rmq_admin,
+                "hostname": broker_hostname,
+            }
+            self.active_alias = alias
+            return f"Connected to {broker_hostname} as '{alias}' (active)"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_select(alias: str) -> str:
+            """Switch the active broker by alias. All subsequent tool calls will target this broker."""
+            if alias not in self.brokers:
+                available = ", ".join(self.brokers.keys()) or "(none)"
+                raise ValueError(f"Unknown alias '{alias}'. Available: {available}")
+            self.active_alias = alias
+            hostname = self.brokers[alias]["hostname"]
+            return f"Active broker: '{alias}' ({hostname})"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_list_registered_brokers() -> list[dict]:
+            """List all registered broker connections and which is active."""
+            return [
+                {
+                    "alias": alias,
+                    "hostname": info["hostname"],
+                    "active": alias == self.active_alias,
+                }
+                for alias, info in self.brokers.items()
+            ]
 
         @self.mcp.tool()
         def rabbitmq_broker_get_guideline(guideline_name: str) -> str:
@@ -151,132 +203,98 @@ class RabbitMQModule:
         @self.mcp.tool()
         def rabbitmq_broker_list_queues() -> list[Any]:
             """List all the queues in the broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_queues(self.rmq_admin)
+            return handle_list_queues(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_list_exchanges() -> list[Any]:
             """List all the exchanges in the broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_exchanges(self.rmq_admin)
+            return handle_list_exchanges(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_list_vhosts() -> list[Any]:
             """List all the virtual hosts (vhosts) in the broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_vhosts(self.rmq_admin)
+            return handle_list_vhosts(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_get_queue_info(queue: str, vhost: str = "/") -> dict:
             """Get detailed information about a specific queue."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             validate_rabbitmq_name(queue, "Queue name")
-            return handle_get_queue_info(self.rmq_admin, queue, vhost)
+            return handle_get_queue_info(self._get_admin(), queue, vhost)
 
         @self.mcp.tool()
         def rabbitmq_broker_get_exchange_info(exchange: str, vhost: str = "/") -> dict:
             """Get detailed information about a specific exchange."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             validate_rabbitmq_name(exchange, "Exchange name")
-            return handle_get_exchange_info(self.rmq_admin, exchange, vhost)
+            return handle_get_exchange_info(self._get_admin(), exchange, vhost)
 
         @self.mcp.tool()
         def rabbitmq_broker_list_shovels() -> list[Any]:
             """Get detailed information about shovels in the RabbitMQ broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_shovels(self.rmq_admin)
+            return handle_list_shovels(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_get_shovel_info(name: str, vhost: str = "/") -> dict:
             """Get detailed information about specific shovel by name that is in a selected virtual host (vhost) in the RabbitMQ broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_shovel(self.rmq_admin, name, vhost)
+            return handle_shovel(self._get_admin(), name, vhost)
 
         @self.mcp.tool()
         def rabbitmq_broker_get_cluster_nodes_info() -> list[Any]:
             """Get the list of nodes and their info in the cluster."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_cluster_nodes(self.rmq_admin)
+            return handle_get_cluster_nodes(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_list_connections() -> list[Any]:
             """List all connections on the RabbitMQ broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_connections(self.rmq_admin)
+            return handle_list_connections(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_list_consumers() -> list[Any]:
             """List all consumers on the RabbitMQ broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_consumers(self.rmq_admin)
+            return handle_list_consumers(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_list_users() -> list[Any]:
             """List all users on the RabbitMQ broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_users(self.rmq_admin)
+            return handle_list_users(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_is_in_alarm() -> bool:
             """Check if the RabbitMQ broker is in alarm."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_is_broker_in_alarm(self.rmq_admin)
+            return handle_is_broker_in_alarm(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_is_quorum_critical() -> bool:
             """Check if there are quorum queues with minimum online quorum."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_is_node_in_quorum_critical(self.rmq_admin)
+            return handle_is_node_in_quorum_critical(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_get_broker_definition() -> dict:
             """Get the RabbitMQ definitions: exchanges, queues, bindings, users, virtual hosts, permissions, topic permissions, and parameters. Everything apart from messages."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_definition(self.rmq_admin)
+            return handle_get_definition(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_get_bindings(
             queue: str | None = None, exchange: str | None = None, vhost: str = "/"
         ) -> list[dict]:
             """Get bindings, optionally filtered by queue or exchange. If neither is specified, returns all bindings in the vhost."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_bindings(self.rmq_admin, queue=queue, exchange=exchange, vhost=vhost)
+            return handle_get_bindings(
+                self._get_admin(), queue=queue, exchange=exchange, vhost=vhost
+            )
 
         @self.mcp.tool()
         def rabbitmq_broker_get_node_information(node_name: str) -> dict:
             """Get detailed information about a specific node in the cluster including memory, disk, uptime, and runtime details."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_node_information(self.rmq_admin, node_name)
+            return handle_get_node_information(self._get_admin(), node_name)
 
         @self.mcp.tool()
         def rabbitmq_broker_list_policies(vhost: str = "/") -> list[dict]:
             """List all policies in a virtual host."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_policies(self.rmq_admin, vhost)
+            return handle_list_policies(self._get_admin(), vhost)
 
         @self.mcp.tool()
         def rabbitmq_broker_get_policy(name: str, vhost: str = "/") -> dict:
             """Get a specific policy by name."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_policy(self.rmq_admin, name, vhost)
+            return handle_get_policy(self._get_admin(), name, vhost)
 
         @self.mcp.tool()
         def rabbitmq_broker_get_messages(
@@ -286,74 +304,56 @@ class RabbitMQModule:
 
             ackmode: ack_requeue_true (peek, default), ack_requeue_false (consume)
             """
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_messages(self.rmq_admin, queue, vhost, count, ackmode)
+            return handle_get_messages(self._get_admin(), queue, vhost, count, ackmode)
 
         @self.mcp.tool()
         def rabbitmq_broker_list_channels() -> list[dict]:
             """List all open channels on the broker."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_list_channels(self.rmq_admin)
+            return handle_list_channels(self._get_admin())
 
         @self.mcp.tool()
         def rabbitmq_broker_get_permissions(vhost: str, user: str) -> dict:
             """Get permissions for a user in a virtual host."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            return handle_get_permissions(self.rmq_admin, vhost, user)
+            return handle_get_permissions(self._get_admin(), vhost, user)
 
     def __register_mutative_tools(self):
         @self.mcp.tool()
         def rabbitmq_broker_delete_queue(queue: str, vhost: str = "/") -> str:
             """Delete a specific queue."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             validate_rabbitmq_name(queue, "Queue name")
-            handle_delete_queue(self.rmq_admin, queue, vhost)
+            handle_delete_queue(self._get_admin(), queue, vhost)
             return f"Queue {queue} successfully deleted"
 
         @self.mcp.tool()
         def rabbitmq_broker_purge_queue(queue: str, vhost: str = "/") -> str:
             """Remove all messages from a specific queue."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             validate_rabbitmq_name(queue, "Queue name")
-            handle_purge_queue(self.rmq_admin, queue, vhost)
+            handle_purge_queue(self._get_admin(), queue, vhost)
             return f"Queue {queue} successfully purged"
 
         @self.mcp.tool()
         def rabbitmq_broker_delete_exchange(exchange: str, vhost: str = "/") -> str:
             """Delete a specific exchange."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             validate_rabbitmq_name(exchange, "Exchange name")
-            handle_delete_exchange(self.rmq_admin, exchange, vhost)
+            handle_delete_exchange(self._get_admin(), exchange, vhost)
             return f"Exchange {exchange} successfully deleted"
 
         @self.mcp.tool()
         def rabbitmq_broker_update_definition(server_definition: dict) -> str:
             """Update The server definitions: exchanges, queues, bindings, users, virtual hosts, permissions, topic permissions, and parameters. Everything apart from messages."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_update_definition(self.rmq_admin, server_definition)
+            handle_update_definition(self._get_admin(), server_definition)
             return "Updated successfully"
 
         @self.mcp.tool()
         def rabbitmq_broker_enqueue(queue: str, message: str) -> str:
             """Publish a message to a specific queue via AMQP. The queue will be declared if it does not exist."""
-            if self.rmq is None:
-                raise AssertionError("RabbitMQ AMQP connection not established.")
-            handle_enqueue(self.rmq, queue, message)
+            handle_enqueue(self._get_rmq(), queue, message)
             return f"Message published to queue {queue}"
 
         @self.mcp.tool()
         def rabbitmq_broker_fanout(exchange: str, message: str) -> str:
             """Publish a message to a fanout exchange via AMQP. The exchange will be declared if it does not exist."""
-            if self.rmq is None:
-                raise AssertionError("RabbitMQ AMQP connection not established.")
-            handle_fanout(self.rmq, exchange, message)
+            handle_fanout(self._get_rmq(), exchange, message)
             return f"Message published to fanout exchange {exchange}"
 
         @self.mcp.tool()
@@ -369,10 +369,8 @@ class RabbitMQModule:
 
             queue_type: quorum (default, recommended), classic, or stream
             """
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             handle_create_queue(
-                self.rmq_admin, queue, vhost, queue_type, durable, auto_delete, arguments
+                self._get_admin(), queue, vhost, queue_type, durable, auto_delete, arguments
             )
             return f"Queue {queue} created"
 
@@ -389,10 +387,8 @@ class RabbitMQModule:
 
             exchange_type: direct, fanout, topic, or headers
             """
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             handle_create_exchange(
-                self.rmq_admin, exchange, exchange_type, vhost, durable, auto_delete, arguments
+                self._get_admin(), exchange, exchange_type, vhost, durable, auto_delete, arguments
             )
             return f"Exchange {exchange} created"
 
@@ -405,9 +401,9 @@ class RabbitMQModule:
             arguments: dict | None = None,
         ) -> str:
             """Create a binding from an exchange to a queue."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_create_binding(self.rmq_admin, exchange, queue, vhost, routing_key, arguments)
+            handle_create_binding(
+                self._get_admin(), exchange, queue, vhost, routing_key, arguments
+            )
             return f"Binding created: {exchange} -> {queue}"
 
         @self.mcp.tool()
@@ -415,9 +411,7 @@ class RabbitMQModule:
             exchange: str, queue: str, props_key: str, vhost: str = "/"
         ) -> str:
             """Delete a binding. The props_key can be found from get_bindings."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_delete_binding(self.rmq_admin, exchange, queue, props_key, vhost)
+            handle_delete_binding(self._get_admin(), exchange, queue, props_key, vhost)
             return f"Binding deleted: {exchange} -> {queue}"
 
         @self.mcp.tool()
@@ -435,19 +429,15 @@ class RabbitMQModule:
             definition: policy settings (e.g. {'ha-mode': 'all'}, {'max-length': 1000})
             apply_to: all, queues, exchanges, or classic_queues
             """
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             handle_create_policy(
-                self.rmq_admin, name, pattern, definition, vhost, priority, apply_to
+                self._get_admin(), name, pattern, definition, vhost, priority, apply_to
             )
             return f"Policy {name} created"
 
         @self.mcp.tool()
         def rabbitmq_broker_delete_policy(name: str, vhost: str = "/") -> str:
             """Delete a policy."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_delete_policy(self.rmq_admin, name, vhost)
+            handle_delete_policy(self._get_admin(), name, vhost)
             return f"Policy {name} deleted"
 
         @self.mcp.tool()
@@ -459,34 +449,26 @@ class RabbitMQModule:
             properties: dict | None = None,
         ) -> dict:
             """Publish a message via the HTTP Management API. Use for diagnostics — for production publishing, use AMQP (enqueue/fanout tools)."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
             return handle_publish_message(
-                self.rmq_admin, exchange, routing_key, payload, vhost, properties
+                self._get_admin(), exchange, routing_key, payload, vhost, properties
             )
 
         @self.mcp.tool()
         def rabbitmq_broker_close_connection(name: str) -> str:
             """Close a specific connection by name. Get connection names from list_connections."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_close_connection(self.rmq_admin, name)
+            handle_close_connection(self._get_admin(), name)
             return f"Connection {name} closed"
 
         @self.mcp.tool()
         def rabbitmq_broker_create_vhost(name: str) -> str:
             """Create a virtual host."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_create_vhost(self.rmq_admin, name)
+            handle_create_vhost(self._get_admin(), name)
             return f"Vhost {name} created"
 
         @self.mcp.tool()
         def rabbitmq_broker_delete_vhost(name: str) -> str:
             """Delete a virtual host. WARNING: this deletes all queues, exchanges, bindings, and permissions in the vhost."""
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_delete_vhost(self.rmq_admin, name)
+            handle_delete_vhost(self._get_admin(), name)
             return f"Vhost {name} deleted"
 
         @self.mcp.tool()
@@ -501,7 +483,5 @@ class RabbitMQModule:
 
             configure/write/read: regex patterns for allowed resource names (default '.*' = all)
             """
-            if self.rmq_admin is None:
-                raise AssertionError("RabbitMQ admin endpoints not connected.")
-            handle_set_permissions(self.rmq_admin, vhost, user, configure, write, read)
+            handle_set_permissions(self._get_admin(), vhost, user, configure, write, read)
             return f"Permissions set for {user} in {vhost}"

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -33,8 +33,8 @@ def module(mock_mcp):
 
 class TestRabbitMQModule:
     def test_init(self, module):
-        assert module.rmq is None
-        assert module.rmq_admin is None
+        assert module.brokers == {}
+        assert module.active_alias is None
 
     def test_register_tools_read_only(self, module):
         module.register_rabbitmq_management_tools(allow_mutative_tools=False)
@@ -53,9 +53,13 @@ class TestRabbitMQModule:
         mock_conn_class.return_value = mock_conn
 
         module.register_rabbitmq_management_tools()
-        # Simulate calling the connection tool
-        module.rmq = mock_conn
-        module.rmq_admin = mock_admin
+        # Simulate registering a broker
+        module.brokers["test"] = {
+            "rmq": mock_conn,
+            "rmq_admin": mock_admin,
+            "hostname": "localhost",
+        }
+        module.active_alias = "test"
 
-        assert module.rmq is not None
-        assert module.rmq_admin is not None
+        assert module._get_admin() is mock_admin
+        assert module._get_rmq() is mock_conn


### PR DESCRIPTION
# Phase 4A: Multi-Broker Connection Registry

**Branch:** `feat/phase4a-multi-broker`
**Base:** `feat/phase3-core-crud` (PR #19)
**Files changed:** 2 (module.py, test_module.py) | +114 / -149 lines (net reduction)

## Summary

Replaces the single-connection model (`self.rmq` / `self.rmq_admin`) with a broker registry that supports multiple simultaneous connections. This is the foundation for blue-green migration (Phase 4B).

## Problem

The README claimed "Connect to multiple brokers in one session" but calling `initialize_connection` a second time silently overwrote the first connection. There was no way to manage multiple brokers.

## Solution

### New data model

```python
self.brokers: dict[str, dict] = {}      # alias -> {rmq, rmq_admin, hostname}
self.active_alias: str | None = None     # currently active broker
```

### Helper methods

```python
def _get_admin(self) -> RabbitMQAdmin    # returns active broker's admin client
def _get_rmq(self) -> RabbitMQConnection # returns active broker's AMQP connection
```

Both raise `AssertionError` if no broker is active — same error behavior as before.

### New tools

| Tool | Tier | Description |
|------|------|-------------|
| `rabbitmq_broker_select` | Critical | Switch active broker by alias |
| `rabbitmq_broker_list_registered_brokers` | Critical | List all connections with active indicator |

### Modified tools

| Tool | Change |
|------|--------|
| `initialize_connection` | Added optional `alias` param (default: hostname). Registers in broker dict, sets as active. |
| `initialize_connection_with_oauth` | Same |

### All 41 existing tools

Updated to use `self._get_admin()` / `self._get_rmq()` instead of direct `self.rmq_admin` / `self.rmq`. Removed 38 inline guard blocks (replaced by guards in helper methods).

## Backward Compatibility

Single-broker usage is unchanged:
1. Call `initialize_connection(hostname="my-broker", ...)` — registers as alias "my-broker", sets active
2. Call any tool — works exactly as before

Multi-broker usage:
1. Call `initialize_connection(hostname="broker-a", alias="blue", ...)`
2. Call `initialize_connection(hostname="broker-b", alias="green", ...)`
3. `green` is now active (last connected)
4. Call `rabbitmq_broker_select(alias="blue")` to switch
5. All subsequent tools target `blue`

## Testing

- All 44 tests pass (updated test_module.py for new data model)
- `ruff check` clean

## Risk

Low. The external tool API is backward compatible. Internal refactor replaces direct attribute access with helper methods. The only breaking change is for code that directly accessed `module.rmq` or `module.rmq_admin` — but these are private implementation details, not part of the MCP tool interface.
