### PR TITLE
feat: Phase 4B — blue-green migration tools

### DIFF
--- a/src/rabbitmq/admin.py
+++ b/src/rabbitmq/admin.py
@@ -336,7 +336,7 @@ class RabbitMQAdmin:
         data = {"configure": configure, "write": write, "read": read}
         self._make_request("PUT", f"permissions/{vhost_encoded}/{user}", data=data)
 
-    # --- Phase 4B: Federation ---
+    # --- Federation ---
 
     def list_federation_upstreams(self, vhost: str = "/") -> list[dict]:
         """List federation upstreams in a vhost."""

--- a/src/rabbitmq/admin.py
+++ b/src/rabbitmq/admin.py
@@ -335,3 +335,25 @@ class RabbitMQAdmin:
         vhost_encoded = quote(vhost, safe="")
         data = {"configure": configure, "write": write, "read": read}
         self._make_request("PUT", f"permissions/{vhost_encoded}/{user}", data=data)
+
+    # --- Phase 4B: Federation ---
+
+    def list_federation_upstreams(self, vhost: str = "/") -> list[dict]:
+        """List federation upstreams in a vhost."""
+        vhost_encoded = quote(vhost, safe="")
+        response = self._make_request("GET", f"parameters/federation-upstream/{vhost_encoded}")
+        return response.json()
+
+    def create_federation_upstream(self, name: str, uri: str, vhost: str = "/", **kwargs) -> None:
+        """Create a federation upstream."""
+        vhost_encoded = quote(vhost, safe="")
+        value = {"uri": uri, **kwargs}
+        data = {"value": value}
+        self._make_request(
+            "PUT", f"parameters/federation-upstream/{vhost_encoded}/{name}", data=data
+        )
+
+    def delete_federation_upstream(self, name: str, vhost: str = "/") -> None:
+        """Delete a federation upstream."""
+        vhost_encoded = quote(vhost, safe="")
+        self._make_request("DELETE", f"parameters/federation-upstream/{vhost_encoded}/{name}")

--- a/src/rabbitmq/handlers.py
+++ b/src/rabbitmq/handlers.py
@@ -451,7 +451,7 @@ def handle_set_permissions(
 
 
 ################################################
-######   Phase 4B: Blue-Green Migration   ######
+######     Blue-Green Migration           ######
 ################################################
 
 

--- a/src/rabbitmq/handlers.py
+++ b/src/rabbitmq/handlers.py
@@ -448,3 +448,143 @@ def handle_set_permissions(
 ) -> None:
     """Set permissions for a user in a vhost."""
     rabbitmq_admin.set_permissions(vhost, user, configure, write, read)
+
+
+################################################
+######   Phase 4B: Blue-Green Migration   ######
+################################################
+
+
+def handle_export_definitions(
+    rabbitmq_admin: RabbitMQAdmin,
+    transforms: list[str] | None = None,
+) -> dict:
+    """Export definitions with optional transformations."""
+    from .transforms import apply_transforms
+
+    defs = rabbitmq_admin.get_broker_definition()
+    if transforms:
+        defs = apply_transforms(defs, transforms)
+    return defs
+
+
+def handle_import_definitions(rabbitmq_admin: RabbitMQAdmin, definitions: dict) -> None:
+    """Import definitions to a broker."""
+    rabbitmq_admin.update_broker_definition(definitions)
+
+
+def handle_compare_definitions(defs_a: dict, defs_b: dict) -> dict:
+    """Compare definitions between two brokers. Returns differences."""
+    result: dict = {}
+    for section in ("queues", "exchanges", "bindings", "policies", "vhosts"):
+        items_a = {_item_key(section, item): item for item in defs_a.get(section, [])}
+        items_b = {_item_key(section, item): item for item in defs_b.get(section, [])}
+        keys_a, keys_b = set(items_a.keys()), set(items_b.keys())
+        missing_in_b = sorted(keys_a - keys_b)
+        extra_in_b = sorted(keys_b - keys_a)
+        if missing_in_b or extra_in_b:
+            result[section] = {}
+            if missing_in_b:
+                result[section]["missing_in_target"] = missing_in_b
+            if extra_in_b:
+                result[section]["extra_in_target"] = extra_in_b
+    return result if result else {"status": "identical"}
+
+
+def _item_key(section: str, item: dict) -> str:
+    """Generate a comparable key for a definition item."""
+    if section == "bindings":
+        return (
+            f"{item.get('source', '')}>{item.get('destination', '')}:{item.get('routing_key', '')}"
+        )
+    return item.get("name", str(item))
+
+
+def handle_setup_federation(
+    rabbitmq_admin: RabbitMQAdmin,
+    upstream_name: str,
+    upstream_uri: str,
+    vhost: str = "/",
+    policy_pattern: str = ".*",
+) -> dict:
+    """Set up federation upstream + policy. Checks for federation plugin first."""
+    # Check federation plugin is enabled
+    overview = rabbitmq_admin.get_overview()
+    # Also check exchange_types for federation presence
+    exchange_types = [et.get("name", "") for et in overview.get("exchange_types", [])]
+    has_federation = "x-federation-upstream" in exchange_types or any(
+        "federation" in str(p).lower() for p in overview.get("enabled_plugins", [])
+    )
+    if not has_federation:
+        return {
+            "status": "error",
+            "message": "Federation plugin not enabled. Enable rabbitmq_federation and "
+            "rabbitmq_federation_management on the target broker.",
+        }
+
+    rabbitmq_admin.create_federation_upstream(upstream_name, upstream_uri, vhost)
+    rabbitmq_admin.create_policy(
+        name=f"federation-{upstream_name}",
+        pattern=policy_pattern,
+        definition={"federation-upstream": upstream_name},
+        vhost=vhost,
+        apply_to="all",
+    )
+    return {
+        "status": "ok",
+        "upstream": upstream_name,
+        "policy": f"federation-{upstream_name}",
+        "pattern": policy_pattern,
+    }
+
+
+def handle_check_migration_readiness(
+    brokers: dict,
+    source_alias: str,
+    target_alias: str,
+) -> dict:
+    """Pre-flight check for blue-green migration."""
+    checks: list[dict] = []
+    go = True
+
+    # Check both aliases exist
+    for alias in (source_alias, target_alias):
+        if alias not in brokers:
+            checks.append({"check": f"broker '{alias}' connected", "status": "FAIL"})
+            go = False
+        else:
+            checks.append({"check": f"broker '{alias}' connected", "status": "PASS"})
+
+    if not go:
+        return {"go": False, "checks": checks}
+
+    # Check alarms on both sides
+    for alias in (source_alias, target_alias):
+        admin = brokers[alias]["rmq_admin"]
+        status = admin.get_alarm_status()
+        ok = status == 200
+        checks.append(
+            {
+                "check": f"'{alias}' no alarms",
+                "status": "PASS" if ok else "FAIL",
+            }
+        )
+        if not ok:
+            go = False
+
+    # Compare topology
+    source_admin = brokers[source_alias]["rmq_admin"]
+    target_admin = brokers[target_alias]["rmq_admin"]
+    source_defs = source_admin.get_broker_definition()
+    target_defs = target_admin.get_broker_definition()
+    diff = handle_compare_definitions(source_defs, target_defs)
+    topology_match = "status" in diff and diff["status"] == "identical"
+    checks.append(
+        {
+            "check": "topology match",
+            "status": "PASS" if topology_match else "WARN",
+            "details": diff if not topology_match else None,
+        }
+    )
+
+    return {"go": go, "checks": checks}

--- a/src/rabbitmq/module.py
+++ b/src/rabbitmq/module.py
@@ -21,7 +21,9 @@ from mcp.server.fastmcp import FastMCP
 from .admin import RabbitMQAdmin
 from .connection import RabbitMQConnection, validate_rabbitmq_name
 from .handlers import (
+    handle_check_migration_readiness,
     handle_close_connection,
+    handle_compare_definitions,
     handle_create_binding,
     handle_create_exchange,
     handle_create_policy,
@@ -33,6 +35,7 @@ from .handlers import (
     handle_delete_queue,
     handle_delete_vhost,
     handle_enqueue,
+    handle_export_definitions,
     handle_fanout,
     handle_get_bindings,
     handle_get_cluster_nodes,
@@ -44,6 +47,7 @@ from .handlers import (
     handle_get_permissions,
     handle_get_policy,
     handle_get_queue_info,
+    handle_import_definitions,
     handle_is_broker_in_alarm,
     handle_is_node_in_quorum_critical,
     handle_list_channels,
@@ -58,6 +62,7 @@ from .handlers import (
     handle_publish_message,
     handle_purge_queue,
     handle_set_permissions,
+    handle_setup_federation,
     handle_shovel,
     handle_update_definition,
 )
@@ -316,6 +321,23 @@ class RabbitMQModule:
             """Get permissions for a user in a virtual host."""
             return handle_get_permissions(self._get_admin(), vhost, user)
 
+        @self.mcp.tool()
+        def rabbitmq_broker_compare_definitions(source_alias: str, target_alias: str) -> dict:
+            """Compare definitions between two connected brokers. Returns missing/extra items per section (queues, exchanges, bindings, policies, vhosts)."""
+            for alias in (source_alias, target_alias):
+                if alias not in self.brokers:
+                    raise ValueError(f"Unknown alias '{alias}'")
+            defs_a = self.brokers[source_alias]["rmq_admin"].get_broker_definition()
+            defs_b = self.brokers[target_alias]["rmq_admin"].get_broker_definition()
+            return handle_compare_definitions(defs_a, defs_b)
+
+        @self.mcp.tool()
+        def rabbitmq_broker_check_migration_readiness(
+            source_alias: str, target_alias: str
+        ) -> dict:
+            """Pre-flight check for blue-green migration. Verifies both brokers connected, no alarms, and topology match."""
+            return handle_check_migration_readiness(self.brokers, source_alias, target_alias)
+
     def __register_mutative_tools(self):
         @self.mcp.tool()
         def rabbitmq_broker_delete_queue(queue: str, vhost: str = "/") -> str:
@@ -485,3 +507,53 @@ class RabbitMQModule:
             """
             handle_set_permissions(self._get_admin(), vhost, user, configure, write, read)
             return f"Permissions set for {user} in {vhost}"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_export_definitions(
+            transforms: list[str] | None = None,
+        ) -> dict:
+            """Export definitions from the active broker with optional transformations.
+
+            transforms: list of transformation names to apply. Available:
+                - strip_cmq_keys: remove classic mirrored queue HA keys from policies
+                - drop_empty_policies: remove policies with empty definitions
+                - convert_classic_to_quorum: change classic queues to quorum type
+                - obfuscate_credentials: replace usernames/passwords with dummy values
+                - exclude_users: remove users section
+                - exclude_permissions: remove permissions sections
+            """
+            return handle_export_definitions(self._get_admin(), transforms)
+
+        @self.mcp.tool()
+        def rabbitmq_broker_import_definitions(definitions: dict) -> str:
+            """Import definitions to the active broker. Merges with existing definitions (RabbitMQ default behavior)."""
+            handle_import_definitions(self._get_admin(), definitions)
+            return "Definitions imported successfully"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_migrate_definitions(
+            source_alias: str,
+            target_alias: str,
+            transforms: list[str] | None = None,
+        ) -> str:
+            """Export definitions from source broker, apply transformations, and import to target broker. The core blue-green migration primitive."""
+            for alias in (source_alias, target_alias):
+                if alias not in self.brokers:
+                    raise ValueError(f"Unknown alias '{alias}'")
+            source_admin = self.brokers[source_alias]["rmq_admin"]
+            target_admin = self.brokers[target_alias]["rmq_admin"]
+            defs = handle_export_definitions(source_admin, transforms)
+            handle_import_definitions(target_admin, defs)
+            return f"Definitions migrated from '{source_alias}' to '{target_alias}'"
+
+        @self.mcp.tool()
+        def rabbitmq_broker_setup_federation(
+            upstream_name: str,
+            upstream_uri: str,
+            vhost: str = "/",
+            policy_pattern: str = ".*",
+        ) -> dict:
+            """Set up federation upstream and policy on the active broker. Creates a bridge for message draining from the upstream broker. Checks that the federation plugin is enabled first."""
+            return handle_setup_federation(
+                self._get_admin(), upstream_name, upstream_uri, vhost, policy_pattern
+            )

--- a/src/rabbitmq/transforms.py
+++ b/src/rabbitmq/transforms.py
@@ -1,0 +1,101 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Definition transformations for blue-green migration workflows.
+
+Matches rabbitmqadmin-ng transformation capabilities. Each function takes
+a definitions dict (from GET /api/definitions) and returns a modified copy.
+"""
+
+import copy
+
+CMQ_KEYS = {
+    "ha-mode",
+    "ha-params",
+    "ha-sync-mode",
+    "ha-sync-batch-size",
+    "ha-promote-on-shutdown",
+    "ha-promote-on-failure",
+}
+
+
+def apply_transforms(definitions: dict, transforms: list[str]) -> dict:
+    """Apply a list of named transformations to a definitions dict."""
+    defs = copy.deepcopy(definitions)
+    dispatch = {
+        "strip_cmq_keys": strip_cmq_keys,
+        "drop_empty_policies": drop_empty_policies,
+        "convert_classic_to_quorum": convert_classic_to_quorum,
+        "obfuscate_credentials": obfuscate_credentials,
+        "exclude_users": exclude_users,
+        "exclude_permissions": exclude_permissions,
+    }
+    for name in transforms:
+        fn = dispatch.get(name)
+        if not fn:
+            available = ", ".join(dispatch.keys())
+            raise ValueError(f"Unknown transform '{name}'. Available: {available}")
+        defs = fn(defs)
+    return defs
+
+
+def strip_cmq_keys(definitions: dict) -> dict:
+    """Remove classic mirrored queue keys from all policy definitions."""
+    for policy in definitions.get("policies", []):
+        defn = policy.get("definition", {})
+        for key in CMQ_KEYS:
+            defn.pop(key, None)
+    return definitions
+
+
+def drop_empty_policies(definitions: dict) -> dict:
+    """Remove policies with empty definitions (e.g. after stripping CMQ keys)."""
+    definitions["policies"] = [p for p in definitions.get("policies", []) if p.get("definition")]
+    return definitions
+
+
+def convert_classic_to_quorum(definitions: dict) -> dict:
+    """Change x-queue-type from classic to quorum in queue arguments."""
+    for queue in definitions.get("queues", []):
+        args = queue.get("arguments", {})
+        if args.get("x-queue-type") == "classic":
+            args["x-queue-type"] = "quorum"
+            queue["durable"] = True
+            # Remove arguments incompatible with quorum queues
+            for key in ("x-max-priority",):
+                args.pop(key, None)
+    return definitions
+
+
+def obfuscate_credentials(definitions: dict) -> dict:
+    """Replace usernames and password hashes with dummy values."""
+    for i, user in enumerate(definitions.get("users", [])):
+        user["name"] = f"user_{i}"
+        user["password_hash"] = "REDACTED"
+        if "hashing_algorithm" in user:
+            user["hashing_algorithm"] = "rabbit_password_hashing_sha256"
+    return definitions
+
+
+def exclude_users(definitions: dict) -> dict:
+    """Remove the users section from definitions."""
+    definitions.pop("users", None)
+    return definitions
+
+
+def exclude_permissions(definitions: dict) -> dict:
+    """Remove permissions and topic_permissions sections from definitions."""
+    definitions.pop("permissions", None)
+    definitions.pop("topic_permissions", None)
+    return definitions


### PR DESCRIPTION
# Phase 4B: Blue-Green Migration Tools

**Branch:** `feat/phase4b-blue-green`
**Base:** `feat/phase4a-multi-broker` (PR #20)
**Files changed:** 4 (+334 lines, 1 new file)

## Summary

Adds definition transformation engine and cross-broker migration tools for blue-green deployments. Directly supports CMQ→QQ migration workflows (TeleTracking, JPMC use cases).

## New File: `transforms.py`

Definition transformation engine matching rabbitmqadmin-ng capabilities:

| Transform | Description | Use Case |
|-----------|-------------|----------|
| `strip_cmq_keys` | Remove `ha-mode`, `ha-params`, `ha-sync-mode` etc. from policies | CMQ → QQ migration |
| `drop_empty_policies` | Remove policies with empty definitions | Pair with strip_cmq_keys |
| `convert_classic_to_quorum` | Change `x-queue-type: classic` → `quorum` in queue args | Modernize queue types |
| `obfuscate_credentials` | Replace usernames/passwords with dummy values | Share definitions for debugging |
| `exclude_users` | Remove users section | Target has own user management |
| `exclude_permissions` | Remove permissions/topic_permissions | Same |

Transforms are chainable via `apply_transforms(definitions, ["strip_cmq_keys", "drop_empty_policies"])`.

## New Tools

### Read-only (2)

| Tool | Description |
|------|-------------|
| `compare_definitions` | Cross-broker topology diff. Compares queues, exchanges, bindings, policies, vhosts between two connected brokers. Returns missing/extra items per section. |
| `check_migration_readiness` | Pre-flight check: both brokers connected, no alarms on either side, topology comparison. Returns go/no-go with detailed check results. |

### Mutative (4)

| Tool | Description |
|------|-------------|
| `export_definitions` | Export from active broker with optional transforms. Wraps `GET /api/definitions`. |
| `import_definitions` | Import to active broker. Wraps `POST /api/definitions` (merge behavior). |
| `migrate_definitions` | Export from source → transform → import to target in one call. The core blue-green primitive. |
| `setup_federation` | Create federation upstream + blanket policy on active broker. **Checks federation plugin is enabled first** — returns error with instructions if not. |

## Blue-Green Workflow (enabled by this PR)

```
1. initialize_connection(hostname="old-broker", alias="blue")
2. initialize_connection(hostname="new-broker", alias="green")
3. check_migration_readiness(source_alias="blue", target_alias="green")
4. migrate_definitions(source="blue", target="green", transforms=["strip_cmq_keys", "drop_empty_policies"])
5. compare_definitions(source_alias="blue", target_alias="green")  # verify
6. select("green") → setup_federation(upstream_uri="amqp://old-broker")
7. Monitor drain, cut over DNS, cleanup
```

## Tool Count After This PR

| Tier | Phase 4A | Phase 4B | Delta |
|------|----------|----------|-------|
| Critical | 5 | 5 | — |
| Read-only | 21 | 23 | +2 |
| Mutative | 17 | 21 | +4 |
| **Total** | **43** | **49** | **+6** |

## Testing

- All 44 existing tests pass
- `ruff check` clean
- Transforms are pure functions operating on dicts — easy to unit test (deferred to Phase 6 integration tests)

## Risk

Medium. Migration tools are powerful — `migrate_definitions` imports topology to a target broker, `setup_federation` creates upstream links. All gated behind `--allow-mutative-tools`. The `check_migration_readiness` pre-flight tool is designed to be called first as a safety check.
