### PR TITLE
feat: Phase 5 — extended health checks and ops tools

### DIFF
--- a/src/rabbitmq/admin.py
+++ b/src/rabbitmq/admin.py
@@ -357,3 +357,46 @@ class RabbitMQAdmin:
         """Delete a federation upstream."""
         vhost_encoded = quote(vhost, safe="")
         self._make_request("DELETE", f"parameters/federation-upstream/{vhost_encoded}/{name}")
+
+    # --- Phase 5: Health & Ops ---
+
+    def check_local_alarms(self) -> dict:
+        """Check for local alarms."""
+        response = self._make_request("GET", "health/checks/local-alarms")
+        return {"status": response.status_code, "ok": response.status_code == 200}
+
+    def check_certificate_expiration(self, within: int = 30, unit: str = "days") -> dict:
+        """Check if any certificates expire within the given timeframe."""
+        response = self._make_request(
+            "GET", f"health/checks/certificate-expiration/{within}/{unit}"
+        )
+        return {"status": response.status_code, "ok": response.status_code == 200}
+
+    def check_protocol_listener(self, protocol: str) -> dict:
+        """Check if a protocol listener is active."""
+        response = self._make_request("GET", f"health/checks/protocol-listener/{protocol}")
+        return {"status": response.status_code, "ok": response.status_code == 200}
+
+    def check_virtual_hosts(self) -> dict:
+        """Check health of all virtual hosts."""
+        response = self._make_request("GET", "health/checks/virtual-hosts")
+        return {"status": response.status_code, "ok": response.status_code == 200}
+
+    def list_feature_flags(self) -> list[dict]:
+        """List all feature flags."""
+        response = self._make_request("GET", "feature-flags")
+        return response.json()
+
+    def list_deprecated_features_in_use(self) -> list[dict]:
+        """List deprecated features currently in use."""
+        response = self._make_request("GET", "deprecated-features/used")
+        return response.json()
+
+    def rebalance_queues(self) -> None:
+        """Rebalance queue leaders across cluster nodes."""
+        self._make_request("POST", "rebalance/queues", data={})
+
+    def whoami(self) -> dict:
+        """Get the current authenticated user."""
+        response = self._make_request("GET", "whoami")
+        return response.json()

--- a/src/rabbitmq/admin.py
+++ b/src/rabbitmq/admin.py
@@ -358,7 +358,7 @@ class RabbitMQAdmin:
         vhost_encoded = quote(vhost, safe="")
         self._make_request("DELETE", f"parameters/federation-upstream/{vhost_encoded}/{name}")
 
-    # --- Phase 5: Health & Ops ---
+    # --- Health & Ops ---
 
     def check_local_alarms(self) -> dict:
         """Check for local alarms."""

--- a/src/rabbitmq/admin.py
+++ b/src/rabbitmq/admin.py
@@ -360,27 +360,27 @@ class RabbitMQAdmin:
 
     # --- Health & Ops ---
 
+    def _health_check(self, endpoint: str) -> dict:
+        """Make a health check request that doesn't raise on non-2xx status."""
+        url = f"{self.base_url}/{endpoint}"
+        response = requests.get(url, headers=self.headers, verify=True)
+        return {"status": response.status_code, "ok": response.status_code == 200}
+
     def check_local_alarms(self) -> dict:
         """Check for local alarms."""
-        response = self._make_request("GET", "health/checks/local-alarms")
-        return {"status": response.status_code, "ok": response.status_code == 200}
+        return self._health_check("health/checks/local-alarms")
 
     def check_certificate_expiration(self, within: int = 30, unit: str = "days") -> dict:
         """Check if any certificates expire within the given timeframe."""
-        response = self._make_request(
-            "GET", f"health/checks/certificate-expiration/{within}/{unit}"
-        )
-        return {"status": response.status_code, "ok": response.status_code == 200}
+        return self._health_check(f"health/checks/certificate-expiration/{within}/{unit}")
 
     def check_protocol_listener(self, protocol: str) -> dict:
         """Check if a protocol listener is active."""
-        response = self._make_request("GET", f"health/checks/protocol-listener/{protocol}")
-        return {"status": response.status_code, "ok": response.status_code == 200}
+        return self._health_check(f"health/checks/protocol-listener/{protocol}")
 
     def check_virtual_hosts(self) -> dict:
         """Check health of all virtual hosts."""
-        response = self._make_request("GET", "health/checks/virtual-hosts")
-        return {"status": response.status_code, "ok": response.status_code == 200}
+        return self._health_check("health/checks/virtual-hosts")
 
     def list_feature_flags(self) -> list[dict]:
         """List all feature flags."""

--- a/src/rabbitmq/handlers.py
+++ b/src/rabbitmq/handlers.py
@@ -591,7 +591,7 @@ def handle_check_migration_readiness(
 
 
 ################################################
-######   Phase 5: Health & Ops handlers   ######
+######      Health & Ops handlers         ######
 ################################################
 
 

--- a/src/rabbitmq/handlers.py
+++ b/src/rabbitmq/handlers.py
@@ -588,3 +588,42 @@ def handle_check_migration_readiness(
     )
 
     return {"go": go, "checks": checks}
+
+
+################################################
+######   Phase 5: Health & Ops handlers   ######
+################################################
+
+
+def handle_check_local_alarms(rabbitmq_admin: RabbitMQAdmin) -> dict:
+    return rabbitmq_admin.check_local_alarms()
+
+
+def handle_check_certificate_expiration(
+    rabbitmq_admin: RabbitMQAdmin, within: int = 30, unit: str = "days"
+) -> dict:
+    return rabbitmq_admin.check_certificate_expiration(within, unit)
+
+
+def handle_check_protocol_listener(rabbitmq_admin: RabbitMQAdmin, protocol: str) -> dict:
+    return rabbitmq_admin.check_protocol_listener(protocol)
+
+
+def handle_check_virtual_hosts(rabbitmq_admin: RabbitMQAdmin) -> dict:
+    return rabbitmq_admin.check_virtual_hosts()
+
+
+def handle_list_feature_flags(rabbitmq_admin: RabbitMQAdmin) -> list[dict]:
+    return rabbitmq_admin.list_feature_flags()
+
+
+def handle_list_deprecated_features(rabbitmq_admin: RabbitMQAdmin) -> list[dict]:
+    return rabbitmq_admin.list_deprecated_features_in_use()
+
+
+def handle_rebalance_queues(rabbitmq_admin: RabbitMQAdmin) -> None:
+    rabbitmq_admin.rebalance_queues()
+
+
+def handle_whoami(rabbitmq_admin: RabbitMQAdmin) -> dict:
+    return rabbitmq_admin.whoami()

--- a/src/rabbitmq/handlers.py
+++ b/src/rabbitmq/handlers.py
@@ -596,34 +596,42 @@ def handle_check_migration_readiness(
 
 
 def handle_check_local_alarms(rabbitmq_admin: RabbitMQAdmin) -> dict:
+    """Check for local alarms on the target node."""
     return rabbitmq_admin.check_local_alarms()
 
 
 def handle_check_certificate_expiration(
     rabbitmq_admin: RabbitMQAdmin, within: int = 30, unit: str = "days"
 ) -> dict:
+    """Check if any certificates expire within the given timeframe."""
     return rabbitmq_admin.check_certificate_expiration(within, unit)
 
 
 def handle_check_protocol_listener(rabbitmq_admin: RabbitMQAdmin, protocol: str) -> dict:
+    """Check if a protocol listener is active."""
     return rabbitmq_admin.check_protocol_listener(protocol)
 
 
 def handle_check_virtual_hosts(rabbitmq_admin: RabbitMQAdmin) -> dict:
+    """Check health of all virtual hosts."""
     return rabbitmq_admin.check_virtual_hosts()
 
 
 def handle_list_feature_flags(rabbitmq_admin: RabbitMQAdmin) -> list[dict]:
+    """List all feature flags and their states."""
     return rabbitmq_admin.list_feature_flags()
 
 
 def handle_list_deprecated_features(rabbitmq_admin: RabbitMQAdmin) -> list[dict]:
+    """List deprecated features currently in use."""
     return rabbitmq_admin.list_deprecated_features_in_use()
 
 
 def handle_rebalance_queues(rabbitmq_admin: RabbitMQAdmin) -> None:
+    """Rebalance queue leaders across cluster nodes."""
     rabbitmq_admin.rebalance_queues()
 
 
 def handle_whoami(rabbitmq_admin: RabbitMQAdmin) -> dict:
+    """Get the current authenticated user."""
     return rabbitmq_admin.whoami()

--- a/src/rabbitmq/module.py
+++ b/src/rabbitmq/module.py
@@ -21,7 +21,11 @@ from mcp.server.fastmcp import FastMCP
 from .admin import RabbitMQAdmin
 from .connection import RabbitMQConnection, validate_rabbitmq_name
 from .handlers import (
+    handle_check_certificate_expiration,
+    handle_check_local_alarms,
     handle_check_migration_readiness,
+    handle_check_protocol_listener,
+    handle_check_virtual_hosts,
     handle_close_connection,
     handle_compare_definitions,
     handle_create_binding,
@@ -53,7 +57,9 @@ from .handlers import (
     handle_list_channels,
     handle_list_connections,
     handle_list_consumers,
+    handle_list_deprecated_features,
     handle_list_exchanges,
+    handle_list_feature_flags,
     handle_list_policies,
     handle_list_queues,
     handle_list_shovels,
@@ -61,10 +67,12 @@ from .handlers import (
     handle_list_vhosts,
     handle_publish_message,
     handle_purge_queue,
+    handle_rebalance_queues,
     handle_set_permissions,
     handle_setup_federation,
     handle_shovel,
     handle_update_definition,
+    handle_whoami,
 )
 
 
@@ -338,6 +346,49 @@ class RabbitMQModule:
             """Pre-flight check for blue-green migration. Verifies both brokers connected, no alarms, and topology match."""
             return handle_check_migration_readiness(self.brokers, source_alias, target_alias)
 
+        @self.mcp.tool()
+        def rabbitmq_broker_check_local_alarms() -> dict:
+            """Check for local alarms on the active broker."""
+            return handle_check_local_alarms(self._get_admin())
+
+        @self.mcp.tool()
+        def rabbitmq_broker_check_certificate_expiration(
+            within: int = 30, unit: str = "days"
+        ) -> dict:
+            """Check if any TLS certificates expire within the given timeframe.
+
+            unit: days, weeks, or months
+            """
+            return handle_check_certificate_expiration(self._get_admin(), within, unit)
+
+        @self.mcp.tool()
+        def rabbitmq_broker_check_protocol_listener(protocol: str) -> dict:
+            """Check if a protocol listener is active.
+
+            protocol: amqp091, amqp10, mqtt, stomp, web-mqtt, web-stomp, http, https
+            """
+            return handle_check_protocol_listener(self._get_admin(), protocol)
+
+        @self.mcp.tool()
+        def rabbitmq_broker_check_virtual_hosts() -> dict:
+            """Check health of all virtual hosts on the active broker."""
+            return handle_check_virtual_hosts(self._get_admin())
+
+        @self.mcp.tool()
+        def rabbitmq_broker_list_feature_flags() -> list[dict]:
+            """List all feature flags and their status."""
+            return handle_list_feature_flags(self._get_admin())
+
+        @self.mcp.tool()
+        def rabbitmq_broker_list_deprecated_features() -> list[dict]:
+            """List deprecated features currently in use. Useful for upgrade planning."""
+            return handle_list_deprecated_features(self._get_admin())
+
+        @self.mcp.tool()
+        def rabbitmq_broker_whoami() -> dict:
+            """Get the current authenticated user on the active broker."""
+            return handle_whoami(self._get_admin())
+
     def __register_mutative_tools(self):
         @self.mcp.tool()
         def rabbitmq_broker_delete_queue(queue: str, vhost: str = "/") -> str:
@@ -557,3 +608,9 @@ class RabbitMQModule:
             return handle_setup_federation(
                 self._get_admin(), upstream_name, upstream_uri, vhost, policy_pattern
             )
+
+        @self.mcp.tool()
+        def rabbitmq_broker_rebalance_queues() -> str:
+            """Rebalance queue leaders across cluster nodes. Useful after adding/removing nodes."""
+            handle_rebalance_queues(self._get_admin())
+            return "Queue rebalance initiated"


### PR DESCRIPTION
# Phase 5: Extended Health Checks & Ops Tools

**Branch:** `feat/phase5-health-ops`
**Base:** `feat/phase4b-blue-green` (PR #21)
**Files changed:** 3 | +141 lines

## Summary

Adds 8 tools covering the remaining RabbitMQ health check endpoints and operational utilities.

## New Read-Only Tools (7)

| Tool | API Endpoint | Description |
|------|-------------|-------------|
| `check_local_alarms` | `GET /health/checks/local-alarms` | Local alarm status |
| `check_certificate_expiration` | `GET /health/checks/certificate-expiration/{within}/{unit}` | TLS cert expiry (configurable: 30 days default) |
| `check_protocol_listener` | `GET /health/checks/protocol-listener/{protocol}` | Verify listeners (amqp091, amqp10, mqtt, stomp, etc.) |
| `check_virtual_hosts` | `GET /health/checks/virtual-hosts` | Health of all vhosts |
| `list_feature_flags` | `GET /feature-flags` | All feature flags and status |
| `list_deprecated_features` | `GET /deprecated-features/used` | Deprecated features in use (upgrade planning) |
| `whoami` | `GET /whoami` | Current authenticated user |

## New Mutative Tools (1)

| Tool | API Endpoint | Description |
|------|-------------|-------------|
| `rebalance_queues` | `POST /rebalance/queues` | Rebalance queue leaders across cluster nodes |

## Tool Count: 57 total (30 read-only, 22 mutative, 5 critical)

## Testing

- All 44 tests pass, `ruff check` clean

## Risk

Low. All additive, no existing behavior changed. Health checks are read-only. Rebalance is gated behind `--allow-mutative-tools`.
