### PR TITLE
feat: auto-connect via RABBITMQ_* env vars for mcp-aggregator compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Use uvx directly in your MCP client config
 - `--http-auth-audience`: Audience for FastMCP Bearer Auth Provider.
 - `--http-auth-required-scopes`: Required scopes for FastMCP Bearer Auth Provider.
 
+#### Environment Variables
+
+If `RABBITMQ_HOST`, `RABBITMQ_USERNAME`, and `RABBITMQ_PASSWORD` are set, the server connects automatically on startup — no `initialize_connection` tool call required. Useful when running behind MCP proxies that spawn a fresh process per session.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RABBITMQ_HOST` | Broker hostname | _(required)_ |
+| `RABBITMQ_USERNAME` | Auth username | _(required)_ |
+| `RABBITMQ_PASSWORD` | Auth password | _(required)_ |
+| `RABBITMQ_PORT` | AMQP port | `5671` |
+| `RABBITMQ_MANAGEMENT_PORT` | Management API port | `443` (TLS) / `15672` (non-TLS) |
+| `RABBITMQ_USE_TLS` | `true` or `false` | `true` |
+| `RABBITMQ_ALIAS` | Broker alias for multi-broker setups | hostname |
+
 ## Usage Examples
 
 ### Strands Agent Example

--- a/src/rabbitmq/module.py
+++ b/src/rabbitmq/module.py
@@ -14,6 +14,7 @@
 # This file is part of the awslabs namespace.
 # It is intentionally minimal to support PEP 420 namespace packages.
 
+import os
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -104,6 +105,55 @@ class RabbitMQModule:
         self.__register_read_only_tools()
         if allow_mutative_tools:
             self.__register_mutative_tools()
+        self._auto_connect_from_env()
+
+    def _auto_connect_from_env(self) -> None:
+        """Connect to a broker at startup if RABBITMQ_* env vars are present.
+
+        In some MCP aggregator setups the server subprocess does not stay
+        running between calls, so connection state set via
+        initialize_connection does not persist. Configuring credentials
+        through the environment makes the tools usable on every spawn.
+
+        Env vars:
+            RABBITMQ_HOST            – broker hostname (required)
+            RABBITMQ_USERNAME        – auth username   (required)
+            RABBITMQ_PASSWORD        – auth password   (required)
+            RABBITMQ_PORT            – AMQP port       (default: 5671)
+            RABBITMQ_MANAGEMENT_PORT – management API port; falls back to
+                                       --management-port CLI arg, then to
+                                       443 / 15672 depending on TLS
+            RABBITMQ_USE_TLS         – "true" or "false" (default: "true")
+            RABBITMQ_ALIAS           – broker alias    (default: hostname)
+        """
+        host = os.environ.get("RABBITMQ_HOST", "")
+        user = os.environ.get("RABBITMQ_USERNAME", "")
+        pw = os.environ.get("RABBITMQ_PASSWORD", "")
+        if not (host and user and pw):
+            return
+        port = int(os.environ.get("RABBITMQ_PORT", "5671") or "5671")
+        mgmt_port_str = os.environ.get("RABBITMQ_MANAGEMENT_PORT", "")
+        mgmt_port = int(mgmt_port_str) if mgmt_port_str else self.default_management_port
+        use_tls = os.environ.get("RABBITMQ_USE_TLS", "true").lower() in ("true", "1", "yes")
+        try:
+            rmq = RabbitMQConnection(
+                hostname=host, username=user, password=pw,
+                port=port, use_tls=use_tls,
+            )
+            rmq_admin = RabbitMQAdmin(
+                hostname=host, username=user, password=pw,
+                use_tls=use_tls, port=mgmt_port,
+            )
+            rmq_admin.test_connection()
+            alias = os.environ.get("RABBITMQ_ALIAS", host)
+            self.brokers[alias] = {
+                "rmq": rmq,
+                "rmq_admin": rmq_admin,
+                "hostname": host,
+            }
+            self.active_alias = alias
+        except Exception:
+            pass  # Fall back to manual initialization via tool call
 
     def __register_critical_tools(self):
         @self.mcp.tool()


### PR DESCRIPTION
I run this server behind an MCP aggregator (fastmcp), and in that setup the subprocess of the mcp-server-rabbitmq does not stay around between calls. Whatever connection the LLM established through `initialize_connection` is gone by the next call. A bit tedious... This feature makes the situation a bit better.

The env-var naming and such are fully up for discussion, in case you guys have preferences. I'd love to see this merged upstream, then I could basically stop using custom forks of the mcp-server-rabbitmq since it will work for my usecase fully then. :--) If not, no worries as well, thanks for your time and consideration.

Cheers

*Issue #, if available:* n/a

*Description of changes:*
This PR adds a small _auto_connect_from_env() step at startup. When RABBITMQ_HOST, RABBITMQ_USERNAME and RABBITMQ_PASSWORD are present in the environment, the server connects on spawn and registers a broker into the existing multi-broker registry. Tools are then usable from the first call. If the variables are not set, nothing changes — manual initialization still works exactly as before.
Optional variables: RABBITMQ_PORT (default 5671), RABBITMQ_MANAGEMENT_PORT, RABBITMQ_USE_TLS (default true), RABBITMQ_ALIAS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
