### PR TITLE
ci(release): auto-create GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,30 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      # Create (or update) the GitHub Release for this tag so the Releases page
+      # reflects every published version. --verify-tag ensures the tag exists;
+      # --generate-notes autofills notes from commits/PRs since the last tag.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping."
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --verify-tag \
+              --generate-notes \
+              --latest
+          fi
+


### PR DESCRIPTION
## Summary
Adds a `github-release` job to `release.yml` that runs after the PyPI publish and creates the GitHub Release for the pushed tag (auto-generated notes, marked latest).

## Why
Tag pushes triggered the PyPI publish but never created a GitHub **Release** — so the repo's Releases page kept showing v2.2.4 as latest even after v3.0.0/v4.0.0 shipped to PyPI. Those two were created by hand; this makes it automatic for future tags.

## Details
- New job `github-release` (needs: publish), `contents: write`.
- Uses `gh release create --verify-tag --generate-notes --latest`.
- **Idempotent**: checks `gh release view` first and skips if the release already exists, so re-runs won't error.

No change to the build or publish jobs.