### PR TITLE
feat: connect at startup from RABBITMQ_*_ENDPOINT URIs (replaces #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for Rab
 - **31 tools** in v4 (enum-based dispatchers), or **61 tools** in v3 (one tool per operation) for broker management - connections, queues, exchanges, health checks, observability, and blue-green migration
 - **16 composable skills** - topology visualization, dead letter analysis, capacity planning, and more
 - **Multi-broker support** - connect multiple brokers simultaneously, switch between them by alias
+- **Startup connection from the environment** - set `RABBITMQ_AMQP_ENDPOINT` so the tools work without a connect call, for hosts that respawn the server per session
 - **Mutative tools gated** behind `--allow-mutative-tools` flag (off by default for safety)
 - **Tool groups** - load only the tools you need with `--tool-groups`
 - **Security hardened** - SSRF protection, credential stripping, TLS warnings, JWKS HTTPS enforcement
@@ -140,6 +141,50 @@ These require the `mutative` tool group to be loaded.
 | Variable | Description |
 |----------|-------------|
 | `FASTMCP_LOG_LEVEL` | Log level: DEBUG, INFO, WARNING (default), ERROR |
+| `RABBITMQ_AMQP_ENDPOINT` | Connect at startup, e.g. `amqps://user:pass@host:5671`. See below. |
+| `RABBITMQ_MANAGEMENT_ENDPOINT` | Management API endpoint, e.g. `https://user:pass@host:443`. See below. |
+| `RABBITMQ_ALIAS` | Alias for the environment-configured broker (default: its hostname) |
+
+#### Connecting at startup
+
+Normally the agent calls the connect tool once per session. Some MCP hosts,
+particularly aggregators and proxies, start a fresh server process per session
+or per tool call, so that connection state does not survive and later calls fail
+with "No active broker". Setting an endpoint URI makes the server connect during
+startup instead, so the tools work on every spawn:
+
+```json
+{
+  "mcpServers": {
+    "rabbitmq": {
+      "command": "uvx",
+      "args": ["amq-mcp-server-rabbitmq@latest", "--v4"],
+      "env": {
+        "RABBITMQ_AMQP_ENDPOINT": "amqps://admin:pass@broker.example.com:5671"
+      }
+    }
+  }
+}
+```
+
+Details:
+
+- **The scheme selects TLS and the default port.** `amqps` is TLS on 5671, `amqp`
+  is plaintext on 5672, `https` is TLS on 443, `http` is plaintext on 15672. An
+  explicit `:port` overrides the default.
+- **Either variable is enough.** Give only `RABBITMQ_AMQP_ENDPOINT` and the
+  management endpoint is derived from it (same host and credentials, matching
+  TLS), and vice versa. Set both when they differ, for example when the
+  management API is on another host or uses separate credentials.
+- **`--management-port` still applies** as the derived management port when
+  `RABBITMQ_MANAGEMENT_ENDPOINT` is not set.
+- **Percent-encode reserved characters in credentials.** A password of `p@ss/word`
+  is written `p%40ss%2Fword`.
+- **Failures are non-fatal.** An unreachable broker or malformed URI logs a
+  warning and leaves the connect tool available, rather than killing the server.
+- Works in both v3 and v4 mode. Credentials are never written to logs or error
+  messages. OAuth is not supported through these variables; use the OAuth connect
+  tool.
 
 ## Tools (v3 layout)
 

--- a/src/rabbitmq/env_config.py
+++ b/src/rabbitmq/env_config.py
@@ -1,0 +1,224 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional broker configuration from the environment.
+
+Some MCP hosts (aggregators and proxies) start a fresh server process per
+session, or even per tool call. State established by the connect tool does not
+survive that, so every subsequent tool fails with "No active broker".
+
+Setting one or both endpoint URIs lets the server connect during startup
+instead, so the tools are usable on every spawn without a connect call:
+
+    RABBITMQ_AMQP_ENDPOINT=amqps://user:pass@broker.example.com:5671
+    RABBITMQ_MANAGEMENT_ENDPOINT=https://user:pass@broker.example.com:443
+
+Either variable is sufficient on its own; the other is derived from it. The
+scheme carries TLS, so there is no separate flag that can contradict the port.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import unquote, urlsplit
+
+from loguru import logger
+
+from .admin import RabbitMQAdmin
+from .connection import RabbitMQConnection
+
+AMQP_ENDPOINT_ENV = "RABBITMQ_AMQP_ENDPOINT"
+MANAGEMENT_ENDPOINT_ENV = "RABBITMQ_MANAGEMENT_ENDPOINT"
+ALIAS_ENV = "RABBITMQ_ALIAS"
+
+# scheme -> (use_tls, default port)
+_SCHEMES: dict[str, tuple[bool, int]] = {
+    "amqp": (False, 5672),
+    "amqps": (True, 5671),
+    "http": (False, 15672),
+    "https": (True, 443),
+}
+_AMQP_SCHEMES = ("amqps", "amqp")
+_MANAGEMENT_SCHEMES = ("https", "http")
+
+
+class BrokerRegistry(Protocol):
+    """The broker-registry surface shared by RabbitMQModule and RabbitMQModuleV4."""
+
+    brokers: dict[str, dict]
+    active_alias: str | None
+    default_management_port: int | None
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """A parsed endpoint URI. Never log this directly; it holds a password."""
+
+    scheme: str
+    hostname: str
+    username: str
+    password: str
+    port: int
+    use_tls: bool
+
+    @property
+    def safe_display(self) -> str:
+        """Credential-free rendering, safe for logs and error messages."""
+        return f"{self.scheme}://{self.hostname}:{self.port}"
+
+
+def parse_endpoint(uri: str, allowed_schemes: tuple[str, ...], var_name: str) -> Endpoint:
+    """Parse an endpoint URI into connection parameters.
+
+    The port defaults from the scheme when omitted (amqps 5671, amqp 5672,
+    https 443, http 15672). Userinfo is percent-decoded, so a password
+    containing reserved characters works when encoded, e.g. "p%40ss" -> "p@ss".
+
+    Raises ValueError with a message that never contains the password.
+    """
+    parts = urlsplit(uri.strip())
+
+    if parts.scheme not in allowed_schemes:
+        expected = " or ".join(f"{s}://" for s in allowed_schemes)
+        raise ValueError(f"{var_name} must start with {expected}, got '{parts.scheme}://'")
+
+    try:
+        port = parts.port
+    except ValueError as exc:
+        # urlsplit defers port validation to attribute access.
+        raise ValueError(f"{var_name} has a non-numeric port") from exc
+
+    if not parts.hostname:
+        raise ValueError(f"{var_name} is missing a hostname")
+    if not parts.username or parts.password is None:
+        raise ValueError(
+            f"{var_name} must include credentials, "
+            f"e.g. {allowed_schemes[0]}://user:pass@{parts.hostname}"
+        )
+
+    use_tls, default_port = _SCHEMES[parts.scheme]
+    return Endpoint(
+        scheme=parts.scheme,
+        hostname=parts.hostname,
+        username=unquote(parts.username),
+        password=unquote(parts.password),
+        port=port or default_port,
+        use_tls=use_tls,
+    )
+
+
+def _derive_management(amqp: Endpoint, default_management_port: int | None) -> Endpoint:
+    """Build a management endpoint from an AMQP one, reusing host and credentials."""
+    scheme = "https" if amqp.use_tls else "http"
+    return Endpoint(
+        scheme=scheme,
+        hostname=amqp.hostname,
+        username=amqp.username,
+        password=amqp.password,
+        port=default_management_port or _SCHEMES[scheme][1],
+        use_tls=amqp.use_tls,
+    )
+
+
+def _derive_amqp(management: Endpoint) -> Endpoint:
+    """Build an AMQP endpoint from a management one, reusing host and credentials."""
+    scheme = "amqps" if management.use_tls else "amqp"
+    return Endpoint(
+        scheme=scheme,
+        hostname=management.hostname,
+        username=management.username,
+        password=management.password,
+        port=_SCHEMES[scheme][1],
+        use_tls=management.use_tls,
+    )
+
+
+def auto_connect_from_env(module: BrokerRegistry, env: Mapping[str, str] | None = None) -> bool:
+    """Register a broker from the environment, if configured.
+
+    Returns True when a broker was registered and made active. Returns False
+    when no endpoint variable is set, or when the configuration is unusable.
+
+    A bad endpoint is logged and skipped rather than raised: aborting startup
+    would leave the host with a dead server, whereas continuing leaves the
+    connect tool available as it was before.
+
+    Note: env-supplied hostnames are deliberately not passed through
+    validate_hostname. That guard exists to stop a model-supplied tool
+    argument from reaching loopback or the cloud metadata endpoint. These
+    values come from the operator's own process environment, and a local
+    broker is the common development case.
+    """
+    env = os.environ if env is None else env
+    amqp_uri = (env.get(AMQP_ENDPOINT_ENV) or "").strip()
+    management_uri = (env.get(MANAGEMENT_ENDPOINT_ENV) or "").strip()
+
+    if not amqp_uri and not management_uri:
+        return False
+
+    try:
+        amqp = parse_endpoint(amqp_uri, _AMQP_SCHEMES, AMQP_ENDPOINT_ENV) if amqp_uri else None
+        management = (
+            parse_endpoint(management_uri, _MANAGEMENT_SCHEMES, MANAGEMENT_ENDPOINT_ENV)
+            if management_uri
+            else None
+        )
+    except ValueError as exc:
+        logger.warning(f"Ignoring broker configuration from the environment: {exc}")
+        return False
+
+    if amqp is None:
+        if management is None:  # unreachable, both-empty returned above
+            return False
+        amqp = _derive_amqp(management)
+    if management is None:
+        management = _derive_management(amqp, module.default_management_port)
+
+    alias = (env.get(ALIAS_ENV) or "").strip() or amqp.hostname
+
+    try:
+        rmq = RabbitMQConnection(
+            hostname=amqp.hostname,
+            username=amqp.username,
+            password=amqp.password,
+            port=amqp.port,
+            use_tls=amqp.use_tls,
+        )
+        rmq_admin = RabbitMQAdmin(
+            hostname=management.hostname,
+            username=management.username,
+            password=management.password,
+            use_tls=management.use_tls,
+            port=management.port,
+        )
+        rmq_admin.test_connection()
+    except Exception as exc:
+        logger.warning(
+            f"Could not connect to {management.safe_display} using {AMQP_ENDPOINT_ENV}/"
+            f"{MANAGEMENT_ENDPOINT_ENV}: {type(exc).__name__}: {exc}. "
+            "The connect tool is still available."
+        )
+        return False
+
+    module.brokers[alias] = {
+        "rmq": rmq,
+        "rmq_admin": rmq_admin,
+        "hostname": amqp.hostname,
+    }
+    module.active_alias = alias
+    logger.info(f"Connected to {amqp.safe_display} as '{alias}' from the environment")
+    return True

--- a/src/server.py
+++ b/src/server.py
@@ -11,6 +11,7 @@ from mcp.server.fastmcp import FastMCP
 from .auth import JWKSBearerVerifier
 from .constant import MCP_SERVER_VERSION
 from .rabbitmq.compat_v3 import register_v3_compat_tools
+from .rabbitmq.env_config import BrokerRegistry, auto_connect_from_env
 from .rabbitmq.module import RabbitMQModule
 from .rabbitmq.module_v4 import TOOL_GROUPS, RabbitMQModuleV4
 
@@ -46,6 +47,7 @@ class RabbitMQMCPServer:
         # Initialize FastMCP
         self.mcp = FastMCP(**mcp_kwargs)
 
+        registry: BrokerRegistry
         if use_v4:
             groups = tool_groups or (
                 ("core", "read", "observability", "health")
@@ -59,10 +61,16 @@ class RabbitMQMCPServer:
             if v1_compat:
                 register_v3_compat_tools(self.mcp, module)
                 self.logger.info("v1-compat: registered deprecated v3 tool aliases")
+            registry = module
         else:
             rmq_module = RabbitMQModule(self.mcp)
             rmq_module.default_management_port = management_port
             rmq_module.register_rabbitmq_management_tools(allow_mutative_tools)
+            registry = rmq_module
+
+        # Optional startup connection from RABBITMQ_*_ENDPOINT. Applies to both
+        # tool layouts, so a single call site keeps them from drifting apart.
+        auto_connect_from_env(registry)
 
     def run(self, args):
         """Run the MCP server with the provided arguments."""

--- a/src/tests/test_env_config.py
+++ b/src/tests/test_env_config.py
@@ -1,0 +1,265 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.rabbitmq.env_config import (
+    _AMQP_SCHEMES,
+    _MANAGEMENT_SCHEMES,
+    ALIAS_ENV,
+    AMQP_ENDPOINT_ENV,
+    MANAGEMENT_ENDPOINT_ENV,
+    auto_connect_from_env,
+    parse_endpoint,
+)
+from src.rabbitmq.module import RabbitMQModule
+from src.rabbitmq.module_v4 import RabbitMQModuleV4
+
+# Both tool layouts must behave identically. Parametrizing here is what keeps
+# the v4 path from silently missing the feature.
+MODULE_CLASSES = [RabbitMQModule, RabbitMQModuleV4]
+
+
+@pytest.fixture(params=MODULE_CLASSES, ids=["v3", "v4"])
+def module(request):
+    return request.param(MagicMock())
+
+
+class TestParseEndpoint:
+    @pytest.mark.parametrize(
+        "uri,expected_port,expected_tls",
+        [
+            ("amqps://u:p@host", 5671, True),
+            ("amqp://u:p@host", 5672, False),
+            ("amqps://u:p@host:5555", 5555, True),
+            ("amqp://u:p@host:5555", 5555, False),
+        ],
+    )
+    def test_amqp_scheme_sets_tls_and_default_port(self, uri, expected_port, expected_tls):
+        endpoint = parse_endpoint(uri, _AMQP_SCHEMES, AMQP_ENDPOINT_ENV)
+        assert endpoint.port == expected_port
+        assert endpoint.use_tls is expected_tls
+        assert endpoint.hostname == "host"
+
+    @pytest.mark.parametrize(
+        "uri,expected_port,expected_tls",
+        [
+            ("https://u:p@host", 443, True),
+            ("http://u:p@host", 15672, False),
+            ("https://u:p@host:15671", 15671, True),
+        ],
+    )
+    def test_management_scheme_sets_tls_and_default_port(self, uri, expected_port, expected_tls):
+        endpoint = parse_endpoint(uri, _MANAGEMENT_SCHEMES, MANAGEMENT_ENDPOINT_ENV)
+        assert endpoint.port == expected_port
+        assert endpoint.use_tls is expected_tls
+
+    def test_percent_encoded_credentials_are_decoded(self):
+        endpoint = parse_endpoint("amqps://us%40er:p%40ss%2Fword@host", _AMQP_SCHEMES, "V")
+        assert endpoint.username == "us@er"
+        assert endpoint.password == "p@ss/word"
+
+    def test_credentials_are_not_in_safe_display(self):
+        endpoint = parse_endpoint("amqps://user:sup3rsecret@host:5671", _AMQP_SCHEMES, "V")
+        assert endpoint.safe_display == "amqps://host:5671"
+        assert "sup3rsecret" not in endpoint.safe_display
+
+    @pytest.mark.parametrize(
+        "uri,match",
+        [
+            ("http://u:p@host", "must start with"),  # management scheme in the AMQP slot
+            ("amqps://host", "must include credentials"),
+            ("amqps://u@host", "must include credentials"),
+            ("amqps://u:p@host:notaport", "non-numeric port"),
+            ("amqps://u:p@", "missing a hostname"),
+        ],
+    )
+    def test_rejects_bad_uris(self, uri, match):
+        with pytest.raises(ValueError, match=match):
+            parse_endpoint(uri, _AMQP_SCHEMES, AMQP_ENDPOINT_ENV)
+
+    def test_error_message_never_leaks_the_password(self):
+        with pytest.raises(ValueError) as excinfo:
+            parse_endpoint("ftp://user:sup3rsecret@host", _AMQP_SCHEMES, AMQP_ENDPOINT_ENV)
+        assert "sup3rsecret" not in str(excinfo.value)
+
+
+class TestAutoConnectFromEnv:
+    def test_no_env_vars_is_a_no_op(self, module):
+        assert auto_connect_from_env(module, env={}) is False
+        assert module.brokers == {}
+        assert module.active_alias is None
+
+    def test_registers_and_activates_broker(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection") as conn,
+            patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+        ):
+            result = auto_connect_from_env(
+                module, env={AMQP_ENDPOINT_ENV: "amqps://user:pass@broker.example.com:5671"}
+            )
+
+        assert result is True
+        assert module.active_alias == "broker.example.com"
+        assert module.brokers["broker.example.com"]["hostname"] == "broker.example.com"
+        admin.return_value.test_connection.assert_called_once()
+        assert conn.call_args.kwargs == {
+            "hostname": "broker.example.com",
+            "username": "user",
+            "password": "pass",
+            "port": 5671,
+            "use_tls": True,
+        }
+
+    def test_alias_env_overrides_hostname(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection"),
+            patch("src.rabbitmq.env_config.RabbitMQAdmin"),
+        ):
+            auto_connect_from_env(
+                module,
+                env={
+                    AMQP_ENDPOINT_ENV: "amqps://user:pass@broker.example.com",
+                    ALIAS_ENV: "prod",
+                },
+            )
+
+        assert module.active_alias == "prod"
+        assert "prod" in module.brokers
+
+    def test_management_endpoint_derived_from_amqp(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection"),
+            patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+        ):
+            auto_connect_from_env(
+                module, env={AMQP_ENDPOINT_ENV: "amqps://user:pass@broker.example.com"}
+            )
+
+        assert admin.call_args.kwargs["port"] == 443
+        assert admin.call_args.kwargs["use_tls"] is True
+        assert admin.call_args.kwargs["hostname"] == "broker.example.com"
+
+    def test_derived_management_endpoint_is_plaintext_for_amqp(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection"),
+            patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+        ):
+            auto_connect_from_env(module, env={AMQP_ENDPOINT_ENV: "amqp://user:pass@localhost"})
+
+        assert admin.call_args.kwargs["port"] == 15672
+        assert admin.call_args.kwargs["use_tls"] is False
+
+    def test_management_port_cli_arg_wins_over_scheme_default(self, module):
+        module.default_management_port = 15671
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection"),
+            patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+        ):
+            auto_connect_from_env(
+                module, env={AMQP_ENDPOINT_ENV: "amqps://user:pass@broker.example.com"}
+            )
+
+        assert admin.call_args.kwargs["port"] == 15671
+
+    def test_explicit_management_endpoint_wins(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection"),
+            patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+        ):
+            auto_connect_from_env(
+                module,
+                env={
+                    AMQP_ENDPOINT_ENV: "amqps://user:pass@broker.example.com",
+                    MANAGEMENT_ENDPOINT_ENV: "https://mgmtuser:mgmtpass@mgmt.example.com:8443",
+                },
+            )
+
+        assert admin.call_args.kwargs["hostname"] == "mgmt.example.com"
+        assert admin.call_args.kwargs["username"] == "mgmtuser"
+        assert admin.call_args.kwargs["port"] == 8443
+
+    def test_amqp_endpoint_derived_from_management_only(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection") as conn,
+            patch("src.rabbitmq.env_config.RabbitMQAdmin"),
+        ):
+            result = auto_connect_from_env(
+                module,
+                env={MANAGEMENT_ENDPOINT_ENV: "https://user:pass@broker.example.com:443"},
+            )
+
+        assert result is True
+        assert conn.call_args.kwargs["port"] == 5671
+        assert conn.call_args.kwargs["use_tls"] is True
+
+    def test_unreachable_broker_warns_and_leaves_registry_empty(self, module):
+        with (
+            patch("src.rabbitmq.env_config.RabbitMQConnection"),
+            patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+        ):
+            admin.return_value.test_connection.side_effect = OSError("connection refused")
+            result = auto_connect_from_env(
+                module, env={AMQP_ENDPOINT_ENV: "amqps://user:pass@broker.example.com"}
+            )
+
+        assert result is False
+        assert module.brokers == {}
+        assert module.active_alias is None
+
+    def test_malformed_endpoint_is_skipped_not_raised(self, module):
+        result = auto_connect_from_env(module, env={AMQP_ENDPOINT_ENV: "not-a-uri"})
+        assert result is False
+        assert module.brokers == {}
+
+    def test_failure_log_does_not_leak_the_password(self, module, capsys):
+        from loguru import logger
+
+        logger.remove()
+        logger.add(lambda msg: print(msg, end=""), level="DEBUG")
+        try:
+            with (
+                patch("src.rabbitmq.env_config.RabbitMQConnection"),
+                patch("src.rabbitmq.env_config.RabbitMQAdmin") as admin,
+            ):
+                admin.return_value.test_connection.side_effect = OSError("refused")
+                auto_connect_from_env(
+                    module,
+                    env={AMQP_ENDPOINT_ENV: "amqps://user:sup3rsecret@broker.example.com"},
+                )
+        finally:
+            logger.remove()
+
+        assert "sup3rsecret" not in capsys.readouterr().out
+
+    def test_success_log_does_not_leak_the_password(self, module, capsys):
+        from loguru import logger
+
+        logger.remove()
+        logger.add(lambda msg: print(msg, end=""), level="DEBUG")
+        try:
+            with (
+                patch("src.rabbitmq.env_config.RabbitMQConnection"),
+                patch("src.rabbitmq.env_config.RabbitMQAdmin"),
+            ):
+                auto_connect_from_env(
+                    module,
+                    env={AMQP_ENDPOINT_ENV: "amqps://user:sup3rsecret@broker.example.com"},
+                )
+        finally:
+            logger.remove()
+
+        assert "sup3rsecret" not in capsys.readouterr().out


### PR DESCRIPTION
Replaces #42, incorporating the review feedback there. Credit to @mrnicegyu11 for the original patch and the use case, @the-mikedavis for the URI design, and @gitfool for pushing on v4 coverage.

## Problem

Some MCP hosts (aggregators, proxies) start a fresh server process per session, or per tool call. State established by the connect tool does not survive that, so every later tool fails with "No active broker". @gitfool reported working around it with a PreToolUse hook.

## Approach

Endpoint URIs rather than one variable per field, as @the-mikedavis suggested on #42:

```
RABBITMQ_AMQP_ENDPOINT=amqps://user:pass@broker.example.com:5671
RABBITMQ_MANAGEMENT_ENDPOINT=https://user:pass@broker.example.com:443
```

Beyond being shorter than the 7 variables in #42, this removes a real failure mode: with a separate `RABBITMQ_USE_TLS` flag and a `RABBITMQ_PORT`, `use_tls=false` with port 5671 is silently accepted. In URI form the scheme carries TLS, so the two cannot disagree.

**Either variable alone is enough**; the other is derived from it using the same host, credentials, and TLS setting. The minimum configuration is therefore one line. Set both when they genuinely differ, e.g. a management API on another host or with separate credentials. `--management-port` still applies as the derived management port.

## Differences from #42

| #42 | Here |
|-----|------|
| 7 discrete variables | 2 URIs plus optional `RABBITMQ_ALIAS` |
| `except Exception: pass` | Logs a warning with the reason. The silent version would now fail CI on bandit B110, since `[tool.bandit]` skips only B101 |
| Hooked into `module.py` only, so `--v4` silently missed it | One call site in `server.py`, so both layouts get it; tests are parametrized over both classes |
| TLS as an independent flag | TLS from the URI scheme |
| No credential encoding handling | Userinfo percent-decoded, so `p%40ss%2Fword` becomes `p@ss/word` |

## Security notes

- Credentials never reach logs or error messages. `Endpoint.safe_display` renders `scheme://host:port` only, and two tests assert a password is absent from both the success and failure log output.
- Env-supplied hostnames are deliberately **not** passed through `validate_hostname`. That guard exists to stop a model-supplied tool argument from reaching loopback or `169.254.169.254`. These values come from the operator's own process environment, and a local broker is the common development case, including the `localhost` example in @the-mikedavis's review. Flagging explicitly in case you would rather keep the guard on this path too.
- Failures are non-fatal by design: a malformed URI or unreachable broker logs a warning and leaves the connect tool working, rather than killing the server and leaving the host with a dead entry.
- OAuth is not supported through these variables; the OAuth connect tool remains the path for that.

## Verification

- **132 tests pass** (93 existing + 39 new). pyright 0 errors, ruff format and check clean, bandit no issues, pip-audit clean.
- The 39 new tests are parametrized over both `RabbitMQModule` and `RabbitMQModuleV4`, so the v4 gap from #42 cannot regress silently.
- **End-to-end against real code, not just mocks:** ran the actual `RabbitMQMCPServer` constructor in both v3 and v4 mode with these variables set, pointed at a stub management API on localhost. Both modes really call `GET /api/queues` with `Authorization: Basic`, credentials decoded from `g%40est` to `guest:g@est`. Repeated against a closed port to confirm the warning is credential-free and the server still constructs.
- No live RabbitMQ broker was used, since there is no container runtime on this machine. The AMQP side is exercised only as far as parameter construction, because `RabbitMQConnection` opens channels lazily and startup only performs the management-API `test_connection`.